### PR TITLE
Remove explicit date field from Organization form

### DIFF
--- a/admin/forms/organizationForm.tsx
+++ b/admin/forms/organizationForm.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { CheckboxField, Component, DateField, FieldView, MultiSelectField, Repeater, SelectField, TextAreaField, TextField } from '@contember/admin'
+import { Component, SelectField, TextAreaField, TextField } from '@contember/admin'
 
 export const OrganizationForm = Component(
 	() => (
@@ -27,7 +27,6 @@ export const OrganizationForm = Component(
 			<TextField field="website" label="Web" />
 			<TextField field="parentOrganization" label="Mateřská organizace" />
 			<TextAreaField field="note" label="Poznámka" />
-			<DateField field="dateRegistered" label="Datum Registrace" />
 		</>
 	),
 	'VolunteerForm',


### PR DESCRIPTION
Closes: https://github.com/cesko-digital/pomahejukrajine-web/issues/71

Toto je mozno trochu "cheating" ale podla modelu by malo stacit odobrat ten date field z formularu a default `'now'` by sa mal postarat o zbytok.