### PR TITLE
Added FrequentlyAskedQuestion as editable entity

### DIFF
--- a/admin/components/Navigation.tsx
+++ b/admin/components/Navigation.tsx
@@ -39,6 +39,9 @@ export const Navigation = () => (
 					<Menu.Item title="Organizace" to="organizations" />
 					<Menu.Item title="Pracovníci" to="organizationManagerList" />
 					<Menu.Item title="Stavy" to="status" />
+					<RoleConditional role={['admin']}>
+						<Menu.Item title="Často kladené otázky" to="faqList" />
+					</RoleConditional>
 				</Menu.Item>
 			</RoleConditional>
 		</RoleConditional>

--- a/admin/pages/faqList.tsx
+++ b/admin/pages/faqList.tsx
@@ -1,0 +1,12 @@
+import { MultiEditPage, PersistButton, TextAreaField, TextField } from '@contember/admin'
+import * as React from 'react'
+
+export default (
+	<MultiEditPage entities="FrequentlyAskedQuestion" rendererProps={{ sortableBy: "order", title: "Často kladené otázky", actions: <PersistButton /> }}>
+        <TextField field="question" label="Otázka" />
+        <TextField field="questionUA" label="Otázka v Ukrajinštině" />
+        <TextAreaField field="answer" label="Odpověď" />
+        <TextAreaField field="answerUA" label="Odpověď v Ukrajinštině" />
+	</MultiEditPage>
+)
+

--- a/api/acl.ts
+++ b/api/acl.ts
@@ -403,7 +403,13 @@ const aclFactory = (model: Model.Schema): Acl.Schema => ({
 							type: true
 						}
 					}
-				}
+				},
+				FrequentlyAskedQuestion: {
+					predicates: {},
+					operations: {
+						read: allField(model, 'FrequentlyAskedQuestion', true),
+					}
+				},
 			},
 		},
 		volunteer: {

--- a/api/migrations/2022-05-25-195734-adding-faq-table.json
+++ b/api/migrations/2022-05-25-195734-adding-faq-table.json
@@ -1,0 +1,133 @@
+{
+	"formatVersion": 3,
+	"modifications": [
+		{
+			"modification": "createEntity",
+			"entity": {
+				"name": "FrequentlyAskedQuestion",
+				"primary": "id",
+				"primaryColumn": "id",
+				"tableName": "frequently_asked_question",
+				"fields": {
+					"id": {
+						"name": "id",
+						"columnName": "id",
+						"columnType": "uuid",
+						"nullable": false,
+						"type": "Uuid"
+					}
+				},
+				"unique": {},
+				"eventLog": {
+					"enabled": true
+				}
+			}
+		},
+		{
+			"modification": "createColumn",
+			"entityName": "FrequentlyAskedQuestion",
+			"field": {
+				"name": "order",
+				"columnName": "order",
+				"columnType": "integer",
+				"nullable": false,
+				"type": "Integer",
+				"default": 0
+			},
+			"fillValue": 0
+		},
+		{
+			"modification": "createColumn",
+			"entityName": "FrequentlyAskedQuestion",
+			"field": {
+				"name": "question",
+				"columnName": "question",
+				"columnType": "text",
+				"nullable": false,
+				"type": "String"
+			}
+		},
+		{
+			"modification": "createColumn",
+			"entityName": "FrequentlyAskedQuestion",
+			"field": {
+				"name": "questionUA",
+				"columnName": "question_ua",
+				"columnType": "text",
+				"nullable": false,
+				"type": "String"
+			}
+		},
+		{
+			"modification": "createColumn",
+			"entityName": "FrequentlyAskedQuestion",
+			"field": {
+				"name": "answer",
+				"columnName": "answer",
+				"columnType": "text",
+				"nullable": false,
+				"type": "String"
+			}
+		},
+		{
+			"modification": "createColumn",
+			"entityName": "FrequentlyAskedQuestion",
+			"field": {
+				"name": "answerUA",
+				"columnName": "answer_ua",
+				"columnType": "text",
+				"nullable": false,
+				"type": "String"
+			}
+		},
+		{
+			"modification": "createUniqueConstraint",
+			"entityName": "FrequentlyAskedQuestion",
+			"unique": {
+				"fields": [
+					"question"
+				],
+				"name": "unique_FrequentlyAskedQuestion_question_b47a0a"
+			}
+		},
+		{
+			"modification": "patchAclSchema",
+			"patch": [
+				{
+					"op": "add",
+					"path": "/roles/admin/entities/FrequentlyAskedQuestion",
+					"value": {
+						"predicates": {},
+						"operations": {
+							"read": {
+								"id": true,
+								"order": true,
+								"question": true,
+								"questionUA": true,
+								"answer": true,
+								"answerUA": true
+							},
+							"create": {
+								"id": true,
+								"order": true,
+								"question": true,
+								"questionUA": true,
+								"answer": true,
+								"answerUA": true
+							},
+							"update": {
+								"id": true,
+								"order": true,
+								"question": true,
+								"questionUA": true,
+								"answer": true,
+								"answerUA": true
+							},
+							"delete": true
+						}
+					}
+				}
+			]
+		}
+	]
+}

--- a/api/model/FrequentlyAskedQuestion.ts
+++ b/api/model/FrequentlyAskedQuestion.ts
@@ -1,0 +1,14 @@
+import { SchemaDefinition as def } from '@contember/schema-definition'
+
+/** Frequently asked question
+ *
+ *  Must have both czech and Ukrainian version, locale should switch fields.
+ */
+export class FrequentlyAskedQuestion {
+    order = def.intColumn().notNull().default(0)
+	question = def.stringColumn().notNull().unique()
+	questionUA = def.stringColumn().notNull()
+
+	answer = def.stringColumn().notNull()
+	answerUA = def.stringColumn().notNull()
+}

--- a/api/model/FrequentlyAskedQuestion.ts
+++ b/api/model/FrequentlyAskedQuestion.ts
@@ -6,9 +6,8 @@ import { SchemaDefinition as def } from '@contember/schema-definition'
  */
 export class FrequentlyAskedQuestion {
     order = def.intColumn().notNull().default(0)
-	question = def.stringColumn().notNull().unique()
-	questionUA = def.stringColumn().notNull()
-
-	answer = def.stringColumn().notNull()
-	answerUA = def.stringColumn().notNull()
+    question = def.stringColumn().notNull().unique()
+    questionUA = def.stringColumn().notNull()
+    answer = def.stringColumn().notNull()
+    answerUA = def.stringColumn().notNull()
 }

--- a/api/model/index.ts
+++ b/api/model/index.ts
@@ -8,6 +8,7 @@ export * from './Reaction'
 export * from './Region'
 export * from './TypesenseSearchToken'
 export * from './Volunteer'
+export * from './FrequentlyAskedQuestion'
 
 // export class Match {
 // 	demand = def.manyHasOne(Demand, 'matches').notNull()


### PR DESCRIPTION
Addresses frontend issue #67
Editable text fields are now designed solely for purpose of FAQ, in case we would like to generalise for different types, we would have to introduce more complex entities. I would prefer to keep these separate for each use case, i.e. add new entity for each type as there is little cost and keeps the types clear for purpose.
@ZdenekMen what other text blocks we would like to add as editable?